### PR TITLE
Check whether stolen recipe is already known

### DIFF
--- a/Dustman.lua
+++ b/Dustman.lua
@@ -859,7 +859,10 @@ local function OnInventorySingleSlotUpdate(_, bagId, slotId, isNewItem)
 	-- Stolen item to do not launder, not in the main block because it must be re-evaluated.
 	if IsItemLinkStolen(itemLink) then
 		if itemType ~= ITEMTYPE_TREASURE then
-			if (Dustman.GetSettings().excludeLaunder[itemType] and quality <= ITEM_QUALITY_NORMAL and (itemType ~= ITEMTYPE_STYLE_MATERIAL or (itemType == ITEMTYPE_STYLE_MATERIAL and Dustman.GetSettings().styleMaterial[itemId] ~= nil))) or (itemType == ITEMTYPE_RECIPE and quality <= Dustman.GetSettings().stolenRecipeQuality) then
+			if Dustman.GetSettings().excludeLaunder[itemType] and (
+				(quality <= ITEM_QUALITY_NORMAL and (itemType ~= ITEMTYPE_STYLE_MATERIAL or (itemType == ITEMTYPE_STYLE_MATERIAL and Dustman.GetSettings().styleMaterial[itemId] ~= nil)))
+				  or (itemType == ITEMTYPE_RECIPE and IsItemLinkRecipeKnown(itemLink) and quality <= Dustman.GetSettings().stolenRecipeQuality)
+			) then
 				if Dustman.GetSettings().destroyNonLaundered then
 					HandleJunk(bagId, slotId, itemLink, sellPrice, true, "FENCE-TO-DESTROY") -- Will destroy the item directly
 					return


### PR DESCRIPTION
Also rearranges the current condition to check whether recipes are excluded from laundering.

* Fixes #4

![image](https://github.com/user-attachments/assets/cf6b497c-1217-47e7-a283-639aafb1b314)
